### PR TITLE
[FLINK-19721] [flink-runtime] Support exponential backoff retries in RpcGatewayRetriever

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategy.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * An implementation of {@link RetryStrategy} that retries that has an exponential backoff with
+ * a cap.
+ */
+public class ExponentialBackoffRetryStrategy implements RetryStrategy {
+	private final int remainingRetries;
+	private final Time currentRetryDelay;
+	private final Time maxRetryDelay;
+
+	/**
+	 * @param remainingRetries number of times to retry
+	 * @param currentRetryDelay the current delay between retries
+	 * @param maxRetryDelay the max delay between retries
+	 */
+	public ExponentialBackoffRetryStrategy(int remainingRetries, Time currentRetryDelay, Time maxRetryDelay) {
+		Preconditions.checkArgument(remainingRetries >= 0, "The number of retries must be greater or equal to 0.");
+		this.remainingRetries = remainingRetries;
+		Preconditions.checkArgument(currentRetryDelay.toMilliseconds() >= 0, "The currentRetryDelay must be positive");
+		this.currentRetryDelay = currentRetryDelay;
+		Preconditions.checkArgument(maxRetryDelay.toMilliseconds() >= 0, "The maxRetryDelay must be positive");
+		this.maxRetryDelay = maxRetryDelay;
+	}
+
+	@Override
+	public int getNumRemainingRetries() {
+		return remainingRetries;
+	}
+
+	@Override
+	public Time getRetryDelay() {
+		return currentRetryDelay;
+	}
+
+	@Override
+	public RetryStrategy getNextRetryStrategy() {
+		int nextRemainingRetries = remainingRetries - 1;
+		Preconditions.checkState(nextRemainingRetries >= 0, "The number of remaining retries must not be negative");
+		long nextRetryDelayMillis = Math.min(2 * currentRetryDelay.toMilliseconds(), maxRetryDelay.toMilliseconds());
+		return new ExponentialBackoffRetryStrategy(nextRemainingRetries, Time.milliseconds(nextRetryDelayMillis), maxRetryDelay);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FixedRetryStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FixedRetryStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * An implementation of {@link RetryStrategy} that retries at a fixed delay.
+ */
+public class FixedRetryStrategy implements RetryStrategy {
+	private final int remainingRetries;
+	private final Time retryDelay;
+
+	/**
+	 * @param remainingRetries number of times to retry
+	 * @param retryDelay delay between retries
+	 */
+	public FixedRetryStrategy(int remainingRetries, Time retryDelay) {
+		Preconditions.checkArgument(remainingRetries >= 0, "The number of retries must be greater or equal to 0.");
+		this.remainingRetries = remainingRetries;
+		Preconditions.checkArgument(retryDelay.toMilliseconds() >= 0, "The retryDelay must be positive");
+		this.retryDelay = retryDelay;
+	}
+
+	@Override
+	public int getNumRemainingRetries() {
+		return remainingRetries;
+	}
+
+	@Override
+	public Time getRetryDelay() {
+		return retryDelay;
+	}
+
+	@Override
+	public RetryStrategy getNextRetryStrategy() {
+		int nextRemainingRetries = remainingRetries - 1;
+		Preconditions.checkState(nextRemainingRetries >= 0, "The number of remaining retries must not be negative");
+		return new FixedRetryStrategy(nextRemainingRetries, retryDelay);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -179,14 +179,35 @@ public class FutureUtils {
 			final Time retryDelay,
 			final Predicate<Throwable> retryPredicate,
 			final ScheduledExecutor scheduledExecutor) {
+		return retryWithDelay(
+				operation,
+				new FixedRetryStrategy(retries, retryDelay),
+				retryPredicate,
+				scheduledExecutor);
+	}
+
+		/**
+		 * Retry the given operation with the given delay in between failures.
+		 *
+		 * @param operation to retry
+		 * @param retryStrategy the RetryStrategy
+		 * @param retryPredicate Predicate to test whether an exception is retryable
+		 * @param scheduledExecutor executor to be used for the retry operation
+		 * @param <T> type of the result
+		 * @return Future which retries the given operation a given amount of times and delays the retry in case of failures
+		 */
+	public static <T> CompletableFuture<T> retryWithDelay(
+			final Supplier<CompletableFuture<T>> operation,
+			final RetryStrategy retryStrategy,
+			final Predicate<Throwable> retryPredicate,
+			final ScheduledExecutor scheduledExecutor) {
 
 		final CompletableFuture<T> resultFuture = new CompletableFuture<>();
 
 		retryOperationWithDelay(
 			resultFuture,
 			operation,
-			retries,
-			retryDelay,
+			retryStrategy,
 			retryPredicate,
 			scheduledExecutor);
 
@@ -209,11 +230,29 @@ public class FutureUtils {
 			final Time retryDelay,
 			final ScheduledExecutor scheduledExecutor) {
 		return retryWithDelay(
-			operation,
-			retries,
-			retryDelay,
-			(throwable) -> true,
-			scheduledExecutor);
+				operation,
+				new FixedRetryStrategy(retries, retryDelay),
+				scheduledExecutor);
+	}
+
+	/**
+	 * Retry the given operation with the given delay in between failures.
+	 *
+	 * @param operation to retry
+	 * @param retryStrategy the RetryStrategy
+	 * @param scheduledExecutor executor to be used for the retry operation
+	 * @param <T> type of the result
+	 * @return Future which retries the given operation a given amount of times and delays the retry in case of failures
+	 */
+	public static <T> CompletableFuture<T> retryWithDelay(
+			final Supplier<CompletableFuture<T>> operation,
+			final RetryStrategy retryStrategy,
+			final ScheduledExecutor scheduledExecutor) {
+		return retryWithDelay(
+				operation,
+				retryStrategy,
+				(throwable) -> true,
+				scheduledExecutor);
 	}
 
 	/**
@@ -274,8 +313,7 @@ public class FutureUtils {
 	private static <T> void retryOperationWithDelay(
 			final CompletableFuture<T> resultFuture,
 			final Supplier<CompletableFuture<T>> operation,
-			final int retries,
-			final Time retryDelay,
+			final RetryStrategy retryStrategy,
 			final Predicate<Throwable> retryPredicate,
 			final ScheduledExecutor scheduledExecutor) {
 
@@ -291,10 +329,11 @@ public class FutureUtils {
 							throwable = ExceptionUtils.stripExecutionException(throwable);
 							if (!retryPredicate.test(throwable)) {
 								resultFuture.completeExceptionally(throwable);
-							} else if (retries > 0) {
+							} else if (retryStrategy.getNumRemainingRetries() > 0) {
+								long retryDelayMillis = retryStrategy.getRetryDelay().toMilliseconds();
 								final ScheduledFuture<?> scheduledFuture = scheduledExecutor.schedule(
-									(Runnable) () -> retryOperationWithDelay(resultFuture, operation, retries - 1, retryDelay, retryPredicate, scheduledExecutor),
-									retryDelay.toMilliseconds(),
+									(Runnable) () -> retryOperationWithDelay(resultFuture, operation, retryStrategy.getNextRetryStrategy(), retryPredicate, scheduledExecutor),
+									retryDelayMillis,
 									TimeUnit.MILLISECONDS);
 
 								resultFuture.whenComplete(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/RetryStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/RetryStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.api.common.time.Time;
+
+/**
+ * Interface that encapsulates retry logic.  An instances should be immutable.
+ */
+public interface RetryStrategy {
+	/**
+	 * @return the number of remaining retries
+	 */
+	int getNumRemainingRetries();
+
+	/**
+	 * @return the current delay if we need to retry
+	 */
+	Time getRetryDelay();
+
+	/**
+	 * @return the next retry strategy to current delay if we need to retry
+	 */
+	RetryStrategy getNextRetryStrategy();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ExponentialBackoffRetryStrategy;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
@@ -339,14 +340,12 @@ public class MiniCluster implements AutoCloseableAsync {
 					commonRpcService,
 					DispatcherGateway.class,
 					DispatcherId::fromUuid,
-					20,
-					Time.milliseconds(20L));
+					new ExponentialBackoffRetryStrategy(21, Time.milliseconds(5L), Time.milliseconds(20L)));
 				resourceManagerGatewayRetriever = new RpcGatewayRetriever<>(
 					commonRpcService,
 					ResourceManagerGateway.class,
 					ResourceManagerId::fromUuid,
-					20,
-					Time.milliseconds(20L));
+					new ExponentialBackoffRetryStrategy(21, Time.milliseconds(5L), Time.milliseconds(20L)));
 				webMonitorLeaderRetriever = new LeaderRetriever();
 
 				resourceManagerLeaderRetriever.start(resourceManagerGatewayRetriever);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetriever.java
@@ -20,7 +20,9 @@ package org.apache.flink.runtime.webmonitor.retriever.impl;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.concurrent.FixedRetryStrategy;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.RetryStrategy;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
@@ -42,9 +44,7 @@ public class RpcGatewayRetriever<F extends Serializable, T extends FencedRpcGate
 	private final RpcService rpcService;
 	private final Class<T> gatewayType;
 	private final Function<UUID, F> fencingTokenMapper;
-
-	private final int retries;
-	private final Time retryDelay;
+	private final RetryStrategy retryStrategy;
 
 	public RpcGatewayRetriever(
 			RpcService rpcService,
@@ -52,14 +52,18 @@ public class RpcGatewayRetriever<F extends Serializable, T extends FencedRpcGate
 			Function<UUID, F> fencingTokenMapper,
 			int retries,
 			Time retryDelay) {
-		this.rpcService = Preconditions.checkNotNull(rpcService);
+		this(rpcService, gatewayType, fencingTokenMapper, new FixedRetryStrategy(retries, retryDelay));
+	}
 
+	public RpcGatewayRetriever(
+			RpcService rpcService,
+			Class<T> gatewayType,
+			Function<UUID, F> fencingTokenMapper,
+			RetryStrategy retryStrategy) {
+		this.rpcService = Preconditions.checkNotNull(rpcService);
 		this.gatewayType = Preconditions.checkNotNull(gatewayType);
 		this.fencingTokenMapper = Preconditions.checkNotNull(fencingTokenMapper);
-
-		Preconditions.checkArgument(retries >= 0, "The number of retries must be greater or equal to 0.");
-		this.retries = retries;
-		this.retryDelay = Preconditions.checkNotNull(retryDelay);
+		this.retryStrategy = Preconditions.checkNotNull(retryStrategy);
 	}
 
 	@Override
@@ -72,8 +76,7 @@ public class RpcGatewayRetriever<F extends Serializable, T extends FencedRpcGate
 							addressLeaderTuple.f0,
 							fencingTokenMapper.apply(addressLeaderTuple.f1),
 							gatewayType)),
-			retries,
-			retryDelay,
+			retryStrategy,
 			rpcService.getScheduledExecutor());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ExponentialBackoffRetryStrategyTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ExponentialBackoffRetryStrategy}.
+ */
+public class ExponentialBackoffRetryStrategyTest extends TestLogger {
+
+	@Test
+	public void testGettersNotCapped() throws Exception {
+		RetryStrategy retryStrategy = new ExponentialBackoffRetryStrategy(10, Time.milliseconds(5L), Time.milliseconds(20L));
+		assertEquals(10, retryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(5L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(9, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(10L), nextRetryStrategy.getRetryDelay());
+	}
+
+	@Test
+	public void testGettersHitCapped() throws Exception {
+		RetryStrategy retryStrategy = new ExponentialBackoffRetryStrategy(5, Time.milliseconds(15L), Time.milliseconds(20L));
+		assertEquals(5, retryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(15L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(4, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(20L), nextRetryStrategy.getRetryDelay());
+	}
+
+	@Test
+	public void testGettersAtCap() throws Exception {
+		RetryStrategy retryStrategy = new ExponentialBackoffRetryStrategy(5, Time.milliseconds(20L), Time.milliseconds(20L));
+		assertEquals(5, retryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(20L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(4, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(20L), nextRetryStrategy.getRetryDelay());
+	}
+
+	/**
+	 * Tests that getting a next RetryStrategy below zero remaining retries fails.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void testRetryFailure() throws Throwable {
+		new ExponentialBackoffRetryStrategy(0, Time.milliseconds(20L), Time.milliseconds(20L)).getNextRetryStrategy();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FixedRetryStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FixedRetryStrategyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link FixedRetryStrategy}.
+ */
+public class FixedRetryStrategyTest extends TestLogger {
+
+	@Test
+	public void testGetters() throws Exception {
+		RetryStrategy retryStrategy = new FixedRetryStrategy(10, Time.milliseconds(5L));
+		assertEquals(10, retryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(5L), retryStrategy.getRetryDelay());
+
+		RetryStrategy nextRetryStrategy = retryStrategy.getNextRetryStrategy();
+		assertEquals(9, nextRetryStrategy.getNumRemainingRetries());
+		assertEquals(Time.milliseconds(5L), nextRetryStrategy.getRetryDelay());
+	}
+
+	/**
+	 * Tests that getting a next RetryStrategy below zero remaining retries fails.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void testRetryFailure() throws Throwable {
+		new FixedRetryStrategy(0, Time.milliseconds(5L)).getNextRetryStrategy();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -95,7 +95,7 @@ public class FutureUtilsTest extends TestLogger {
 	 * Tests that a retry future is failed after all retries have been consumed.
 	 */
 	@Test(expected = FutureUtils.RetryException.class)
-	public void testRetryFailure() throws Throwable {
+	public void testRetryFailureFixedRetries() throws Throwable {
 		final int retries = 3;
 
 		CompletableFuture<?> retryFuture = FutureUtils.retry(
@@ -163,7 +163,7 @@ public class FutureUtilsTest extends TestLogger {
 	 * Tests that retry with delay fails after having exceeded all retries.
 	 */
 	@Test(expected = FutureUtils.RetryException.class)
-	public void testRetryWithDelayFailure() throws Throwable {
+	public void testRetryWithDelayFixedArgsFailure() throws Throwable {
 		CompletableFuture<?> retryFuture = FutureUtils.retryWithDelay(
 			() -> FutureUtils.completedExceptionally(new FlinkException("Test exception")),
 			3,
@@ -178,10 +178,27 @@ public class FutureUtilsTest extends TestLogger {
 	}
 
 	/**
+	 * Tests that retry with delay fails after having exceeded all retries.
+	 */
+	@Test(expected = FutureUtils.RetryException.class)
+	public void testRetryWithDelayRetryStrategyFailure() throws Throwable {
+		CompletableFuture<?> retryFuture = FutureUtils.retryWithDelay(
+				() -> FutureUtils.completedExceptionally(new FlinkException("Test exception")),
+				new FixedRetryStrategy(3, Time.milliseconds(1L)),
+				TestingUtils.defaultScheduledExecutor());
+
+		try {
+			retryFuture.get(TestingUtils.TIMEOUT().toMilliseconds(), TimeUnit.MILLISECONDS);
+		} catch (ExecutionException ee) {
+			throw ExceptionUtils.stripExecutionException(ee);
+		}
+	}
+
+	/**
 	 * Tests that the delay is respected between subsequent retries of a retry future with retry delay.
 	 */
 	@Test
-	public void testRetryWithDelay() throws Exception {
+	public void testRetryWithDelayFixedArgs() throws Exception {
 		final int retries = 4;
 		final Time delay = Time.milliseconds(5L);
 		final AtomicInteger countDown = new AtomicInteger(retries);
@@ -205,7 +222,37 @@ public class FutureUtilsTest extends TestLogger {
 		long completionTime = System.currentTimeMillis() - start;
 
 		assertTrue(result);
-		assertTrue("The completion time should be at least rertries times delay between retries.", completionTime >= retries * delay.toMilliseconds());
+		assertTrue("The completion time should be at least retries times delay between retries.", completionTime >= retries * delay.toMilliseconds());
+	}
+
+	/**
+	 * Tests that the delay is respected between subsequent retries of a retry future with retry delay.
+	 */
+	@Test
+	public void testRetryWithDelayRetryStrategy() throws Exception {
+		final int retries = 4;
+		final Time delay = Time.milliseconds(5L);
+		final AtomicInteger countDown = new AtomicInteger(retries);
+
+		long start = System.currentTimeMillis();
+
+		CompletableFuture<Boolean> retryFuture = FutureUtils.retryWithDelay(
+				() -> {
+					if (countDown.getAndDecrement() == 0) {
+						return CompletableFuture.completedFuture(true);
+					} else {
+						return FutureUtils.completedExceptionally(new FlinkException("Test exception."));
+					}
+				},
+				new ExponentialBackoffRetryStrategy(retries, Time.milliseconds(2L), Time.milliseconds(5L)),
+				TestingUtils.defaultScheduledExecutor());
+
+		Boolean result = retryFuture.get();
+
+		long completionTime = System.currentTimeMillis() - start;
+
+		assertTrue(result);
+		assertTrue("The completion time should be at least retries times delay between retries.", completionTime >= (2 + 4 + 5 + 5));
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This is to speed up tests that spend unnecessary time sleeping.

## Brief change log

- Add a RetryStrategy interface that encapsulates retry configuration details.
- Support it in FuturesUtil.
- Plumb interface to Minicluster utils.

## Verifying this change

This change added tests and can be verified as follows:
- Added unit tests

I could not get the test suite to fully pass locally.  I sent an email to the user group about it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
